### PR TITLE
Fixed pseudo selectors with multiple matches in a selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.0.1 - 2015-10-26
+- Fixed: pseudo selectors with multiple matches in a selector
+
 # 2.0.0 - 2015-08-25
 
 - Removed: compatibility with postcss v4.x

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-selector-matches",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "PostCSS plugin to transform :matches() W3C CSS pseudo class to more compatible CSS selectors",
   "keywords": [
     "postcss",

--- a/src/replaceRuleSelector.js
+++ b/src/replaceRuleSelector.js
@@ -39,7 +39,7 @@ function explodeSelector(selector, options) {
         newParts = []
         postSelectors.forEach(postS => {
           bodySelectors.forEach(s => {
-            newParts.push(pre + s + postS)
+            newParts.push(preWhitespace + pre + s + postS)
           })
         })
       }

--- a/test/index.js
+++ b/test/index.js
@@ -57,6 +57,12 @@ tape("postcss-selector-matches", t => {
   )
 
   t.equal(
+    transform(":matches(tag) :matches(tag2, tag3):hover {}"),
+    "tag tag2:hover, tag tag3:hover {}",
+    "should transform mutltiples :matches() with pseudo after"
+  )
+
+  t.equal(
     transform("tag :matches(tag2 :matches(tag4, tag5), tag3) {}"),
     "tag tag2 tag4, tag tag2 tag5, tag tag3 {}",
     "should transform :matches() recursively"


### PR DESCRIPTION
Hey @MoOx,

So with cssnext I was running some code that had:

```
@custom-selector :--selector a;
@custom-selector :--other-selector b;
:--selector :--other-selector:hover {
```

Which was turning into:

```
ab:hover
```

Which it tracks back to this code here.

Let me know if there are any issues with this.

Thank you for all your hard work on this!
