### PR TITLE
Don't mangle selector parts that don't contain `:matches`

### DIFF
--- a/src/replaceRuleSelector.js
+++ b/src/replaceRuleSelector.js
@@ -50,7 +50,7 @@ function explodeSelector(selector, options) {
       if (postSelectors.length === 0) {
         // the test below is a poor way to try we are facing a piece of a
         // selector...
-        if (pre.indexOf(" ") > -1) {
+        if (position === -1 || pre.indexOf(" ") > -1) {
           newParts = bodySelectors.map((s) => preWhitespace + pre + s)
         }
         else {

--- a/test/index.js
+++ b/test/index.js
@@ -154,5 +154,11 @@ article h3 + p {}`,
     "regression https://github.com/postcss/postcss-selector-matches/issues/10"
   )
 
+  t.equal(
+    transform(":matches(a, b).foo, .bar {}"),
+    "a.foo, b.foo, .bar {}",
+    "regression https://github.com/postcss/postcss-selector-matches/issues/10"
+  )
+
   t.end()
 })


### PR DESCRIPTION
Fixes #10 even harder.
